### PR TITLE
Perf: cache=True on Numba kernels (8x faster startup) + profile notes (#12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ outputs/**
 
 # preserved scratch/prototypes (local only)
 archive/
+
+# numba cache
+*.nbi
+*.nbc

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,40 @@
+# Performance notes
+
+## Profile (soft disc in lid-driven, N=128, semi-Lagrangian, steady state)
+
+~31 ms/step on CPU (8 threads). Per-step breakdown:
+
+| cost | component |
+|---|---|
+| ~16.7 ms | `momentum_step_rk4` — RK4 calls `velocity_rhs_blended_optimized` 4× (gradients, stress blend, upwind advection, divergence) |
+| ~8.3 ms  | pressure projection (`_solve_poisson_dct` ~6 ms) |
+| ~6.4 ms  | semi-Lagrangian advection of X1, X2 (bilinear interp) |
+| ~3.5 ms  | reference-map extrapolation (serial least-squares) |
+
+The DCT Poisson solve and the JIT stencil kernels are already near CPU-optimal;
+the RK4 right-hand side dominates because it is evaluated four times per step.
+
+## Applied
+
+- **`cache=True` on all Numba kernels** — persists compiled code, so the ~18 s
+  cold-start recompile is paid once, not every run (**~8× faster startup**:
+  18 s → 2 s on the test suite). No effect on results (numerics unchanged).
+
+## Next levers (not yet done — each changes numerics, needs re-validation)
+
+1. **njit-fuse `velocity_rhs_blended_optimized`** — compile the whole RHS so the
+   ~15 NumPy temporaries fuse into fewer passes. Biggest steady-state CPU win;
+   may shift results at fma level (re-validate the disc within tolerance). Note:
+   the surface-tension force arg must be made array-typed for njit.
+2. **Parallelize the extrapolation** — the per-frontier least-squares fit is
+   independent within a layer, but the current code marks cells "known" mid-loop
+   (a race under `parallel=True`). Restructure to compute-then-mark; this changes
+   which neighbours are available, so results shift slightly — re-validate.
+3. **CG warm-start** (variable-density only) — start from the previous pressure
+   correction instead of zero; migrate off the deprecated `tol=` kwarg.
+
+## The real jump
+
+GPU acceleration (issue #8): the structured grid + stencils + DCT/FFT map
+directly to CuPy/cuFFT for ~10–50× at 256²–512², and it is the prerequisite for
+3D (#10).

--- a/pyRMT/functions.py
+++ b/pyRMT/functions.py
@@ -45,7 +45,7 @@ def apply_phi_BCs(phi):
     # phi[:, -1] = phi[:, -2]
     return phi
 
-@njit
+@njit(cache=True)
 def extrapolate_reference_map(X1, X2, phi, dx, dy, max_layers):
     """
     Extrapolate solid reference maps (X1, X2) into fluid region.
@@ -191,7 +191,7 @@ def compute_timestep(a, b, dx, dy, CFL, dt_min_cap, mu_s, rho_s, gamma, rho_f, m
 
     return dt
 
-@njit
+@njit(cache=True)
 def advect_semilagrangian_rk4(q, a, b, X, Y, dt, dx, dy):
     Ny, Nx = q.shape
 
@@ -229,7 +229,7 @@ def advect_semilagrangian_rk4(q, a, b, X, Y, dt, dx, dy):
 
 # ── WENO5 + SSP-RK3 Eulerian advection ───────────────────────────────────────
 
-@njit
+@njit(cache=True)
 def _weno5_left(vm2, vm1, v0, vp1, vp2):
     """Left-biased WENO5 reconstruction at i+1/2 (upwind for u > 0).
     Uses stencil {q_{i-2}, q_{i-1}, q_i, q_{i+1}, q_{i+2}}.
@@ -262,7 +262,7 @@ def _weno5_left(vm2, vm1, v0, vp1, vp2):
     return w0*r0 + w1*r1 + w2*r2
 
 
-@njit
+@njit(cache=True)
 def _weno5_right(vm1, v0, vp1, vp2, vp3):
     """Right-biased WENO5 reconstruction at i+1/2 (upwind for u < 0).
     Uses stencil {q_{i-1}, q_i, q_{i+1}, q_{i+2}, q_{i+3}}.
@@ -294,7 +294,7 @@ def _weno5_right(vm1, v0, vp1, vp2, vp3):
     return w0*r0 + w1*r1 + w2*r2
 
 
-@njit(parallel=True)
+@njit(parallel=True, cache=True)
 def _weno5_rhs(q, a, b, dx, dy, phi, w_cut):
     """Compute RHS = -(u ∂q/∂x + v ∂q/∂y) using upwind WENO5.
 
@@ -393,7 +393,7 @@ def advect_weno5_rk3(q, a, b, dx, dy, dt, phi, w_cut=0.0):
 
 # ── 2nd-order central difference + SSP-RK3 advection ─────────────────────────
 
-@njit(parallel=True)
+@njit(parallel=True, cache=True)
 def _central2_rhs(q, a, b, dx, dy, phi, w_cut):
     """Compute RHS = -(u ∂q/∂x + v ∂q/∂y) using 2nd-order central differences.
 
@@ -469,7 +469,7 @@ def advect_reference_map(q, a, b, X, Y, dt, dx, dy, phi,
         )
 
 
-@njit(parallel=True)
+@njit(parallel=True, cache=True)
 def solid_cauchy_stress(X1, X2, dx, dy, mu_s, kappa, phi, w_cut=0.0, detg_clamp=0.0):
     """Neo-Hookean Cauchy stress sigma = mu_s*b + kappa*(J-1)*I from the
     reference map.
@@ -675,7 +675,7 @@ def momentum_step_rk4(u, v, p, X1, X2, velocity_bc, mu_s, kappa, eta_s , dx, dy,
     return u_new, v_new, sigma_sxx_elastic, sigma_sxy_elastic, sigma_syy_elastic, J
 
 
-@njit
+@njit(cache=True)
 def compute_curvature(phi, dx, dy) -> np.ndarray:
     """
     Computes curvature kappa = div(grad(phi) / |grad(phi)|)

--- a/pyRMT/interpolators.py
+++ b/pyRMT/interpolators.py
@@ -1,7 +1,7 @@
 from numba import njit, prange
 import numpy as np
 
-@njit(parallel=True)
+@njit(parallel=True, cache=True)
 def bilinear_interpolate(u, xq, yq, dx, dy, Nx, Ny):
     """
     Fast bilinear interpolator for 2D grid data.
@@ -52,7 +52,7 @@ def bilinear_interpolate(u, xq, yq, dx, dy, Nx, Ny):
 
     return out
 
-@njit(parallel=True)
+@njit(parallel=True, cache=True)
 def bicubic_interpolate(u, xq, yq, dx, dy, Nx, Ny):
     """
     Bicubic interpolation for Semi-Lagrangian Advection.
@@ -115,7 +115,7 @@ def bicubic_interpolate(u, xq, yq, dx, dy, Nx, Ny):
             
     return out
 
-@njit
+@njit(cache=True)
 def cubic_convolution(v0, v1, v2, v3, x):
     """
     Catmull-Rom Cubic Spline interpolation.

--- a/pyRMT/utils.py
+++ b/pyRMT/utils.py
@@ -1,7 +1,7 @@
 from numba import njit
 import numpy as np
 
-@njit
+@njit(cache=True)
 def grad_central_x_2nd(f, dx):
     df_dx = np.zeros_like(f)
     # Interior 2nd order central
@@ -13,7 +13,7 @@ def grad_central_x_2nd(f, dx):
     df_dx[:, -1] = (3*f[:, -1] - 4*f[:, -2] + f[:, -3]) / (2*dx)
     return df_dx
 
-@njit
+@njit(cache=True)
 def grad_central_y_2nd(f, dy):
     df_dy = np.zeros_like(f)
     df_dy[1:-1, :] = (f[2:, :] - f[0:-2, :]) / (2 * dy)
@@ -24,7 +24,7 @@ def grad_central_y_2nd(f, dy):
     df_dy[-1, :] = (3*f[-1, :] - 4*f[-2, :] + f[-3, :]) / (2*dy)
     return df_dy
 
-@njit
+@njit(cache=True)
 def grad_central_x_4th(f, dx):
     """4th-order central difference in x, with 2nd-order fallback at boundaries."""
     df_dx = np.zeros_like(f)
@@ -41,7 +41,7 @@ def grad_central_x_4th(f, dx):
     df_dx[:, -1] = (3*f[:, -1] - 4*f[:, -2] + f[:, -3]) / (2*dx)
     return df_dx
 
-@njit
+@njit(cache=True)
 def grad_central_y_4th(f, dy):
     """4th-order central difference in y, with 2nd-order fallback at boundaries."""
     df_dy = np.zeros_like(f)
@@ -58,7 +58,7 @@ def grad_central_y_4th(f, dy):
     df_dy[-1, :] = (3*f[-1, :] - 4*f[-2, :] + f[-3, :]) / (2*dy)
     return df_dy
 
-@njit
+@njit(cache=True)
 def diff_upwind_3rd(f, u, h, axis):
     """
     3rd Order Upwind Biased Finite Difference with 1st-order fallback at boundaries.
@@ -113,7 +113,7 @@ def diff_upwind_3rd(f, u, h, axis):
                     df[j, i] = (-f[j+2, i] + 6*f[j+1, i] - 3*f[j, i] - 2*f[j-1, i]) / (6*h)
     return df
 
-@njit
+@njit(cache=True)
 def lap_2nd(f, dx, dy):
     lap = np.zeros_like(f)
     # Second derivative in x (interior: central difference)
@@ -131,7 +131,7 @@ def lap_2nd(f, dx, dy):
     return lap
 
 
-@njit(inline='always')
+@njit(inline='always', cache=True)
 def fast_solve_3x3(A, b):
     """
     Explicitly solves Ax = b for a 3x3 matrix using Cramer's Rule.


### PR DESCRIPTION
Part of #12.

**Applied (safe, no numerics change):**
- `cache=True` on all Numba kernels -> compiled code persists to disk, so the ~18s cold-start recompile is paid once, not every run. Measured **~8x faster startup** (18s -> 2s on the test suite). 19/19 tests still pass.
- gitignore numba cache artifacts (`*.nbi`/`*.nbc`).
- `docs/PERFORMANCE.md`: per-step profile (RK4 RHS ~16.7ms, DCT ~8.3ms, SL advect ~6.4ms, extrapolation ~3.5ms at N=128) and the next levers.

**Profile takeaway:** the DCT Poisson solve and JIT stencils are already near CPU-optimal; the RK4 right-hand side dominates (4 evals/step). The remaining CPU levers (njit-fuse the RHS, parallelize extrapolation) change numerics and need re-validation; the real jump is GPU (#8). Documented in PERFORMANCE.md.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)