### PR TITLE
Multi-solid contact: blended-stress momentum step + two-disc collision (#2)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -48,6 +48,27 @@ The semi-Lagrangian scheme is retained as the default because the Eulerian
 schemes can distort the level set; switch only when you specifically want the
 non-dissipative central/WENO behaviour.
 
+## Solid-solid contact (`two_disc_contact.py`)
+
+Multi-solid support: each solid carries its own reference map; the two solid
+stresses and the fluid stress are combined with the n=2 one-fluid mixture
+(Jain 2019 Eq. 29) and a short-range repulsion (`compute_contact_force`) is added
+in `momentum_step_rk4_2solids`.
+
+`two_disc_contact.py` drives two soft discs together. The contact force prevents
+inter-penetration: the centre gap approaches but stays above 2R (no pass-through),
+the discs compress elastically (min J ~ 0.74), and the run is stable.
+
+```bash
+python benchmarks/two_disc_contact.py 64 1.5 0.15 2.0   # N, t_end, V0, k_rep
+```
+
+Notes / open items: the approach is cushioned by the incompressible fluid between
+the discs (physical lubrication), and the contact influence band (w_c) engages
+before hard contact, so in this gentle setup the discs settle rather than show a
+sharp rebound. Reproducing the energetic collision/rebound of Jain Sec. 4.6
+(stiff solids, high density ratio) is a tuning + validation follow-up.
+
 ## Surface tension (`gamma`)
 
 Continuum-surface-force model `f = -gamma * kappa * grad(H)` with curvature

--- a/benchmarks/two_disc_contact.py
+++ b/benchmarks/two_disc_contact.py
@@ -1,0 +1,139 @@
+"""Two soft discs colliding — solid-solid contact (Jain 2019 Sec. 3.6/4.6).
+
+Two neo-Hookean discs are given approaching velocities; the short-range repulsive
+contact force prevents inter-penetration and they rebound. Each disc carries its
+OWN reference map; the two solid stresses + fluid stress are combined with the
+n=2 one-fluid mixture (Jain Eq. 29), and the contact force is added in the
+momentum step (`momentum_step_rk4_2solids`).
+
+Diagnostic: the centre-to-centre gap decreases (approach), reaches a positive
+minimum (contact, no pass-through), then increases (rebound).
+
+Usage:
+    python benchmarks/two_disc_contact.py [N] [t_end] [V0] [k_rep]
+"""
+
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pyRMT.functions import (
+    create_grid, apply_phi_BCs, extrapolate_reference_map, compute_timestep,
+    advect_reference_map, rebuild_phi_from_reference_map, momentum_step_rk4_2solids,
+    smoothed_heaviside, pressure_projection_amg, build_poisson_matrix,
+    _precompute_poisson_eigenvalues,
+)
+from benchmarks.common import (free_slip_box_bc, initialize_disc,
+                               check_narrow_band, disc_centroid, ensure_dir)
+
+
+def run(N=128, t_end=2.0, V0=0.15, k_rep=2.0, out_root="outputs"):
+    Lx = Ly = 1.0
+    X, Y, dx, dy = create_grid(N, N, Lx, Ly)
+    R = 0.15
+    xa0, xb0, yc = 0.30, 0.70, 0.50          # left / right disc centres
+    phi_init_a = lambda Xq, Yq: initialize_disc(Xq, Yq, xa0, yc, R)
+    phi_init_b = lambda Xq, Yq: initialize_disc(Xq, Yq, xb0, yc, R)
+
+    phi_a = apply_phi_BCs(phi_init_a(X, Y))
+    phi_b = apply_phi_BCs(phi_init_b(X, Y))
+
+    mu_s, kappa, rho_s, eta_s = 1.0, 0.0, 1.0, 0.0
+    mu_f, rho_f = 0.01, 1.0          # low fluid viscosity -> less drag, clearer rebound
+    w_t = 2.0 * dx
+    w_c = 3.0 * dx                           # contact influence half-width
+    nl = max(3, check_narrow_band(w_t, dx, 3))
+
+    # reference maps (one per disc)
+    ma = (phi_a <= 0).astype(float); mb = (phi_b <= 0).astype(float)
+    X1a, X2a = extrapolate_reference_map(X * ma, Y * ma, phi_a, dx, dy, nl)
+    X1b, X2b = extrapolate_reference_map(X * mb, Y * mb, phi_b, dx, dy, nl)
+
+    # approaching velocity field: left disc -> +x, right disc -> -x
+    Ha = smoothed_heaviside(phi_a, w_t); Hb = smoothed_heaviside(phi_b, w_t)
+    a = V0 * (1 - Ha) - V0 * (1 - Hb)
+    b = np.zeros((N, N))
+    a, b = free_slip_box_bc(a, b)
+    p = np.zeros((N, N))
+
+    CFL, dt_min_cap = 0.2, 1e-3
+    A = build_poisson_matrix(N, N, dx, dy)
+    eig = _precompute_poisson_eigenvalues(N, N, dx, dy)
+    ml = None
+
+    out_dir = ensure_dir(os.path.join(out_root, f"two_disc_contact_N{N}"))
+    print(f"[contact] N={N} R={R} V0={V0} k_rep={k_rep} mu_s={mu_s} t_end={t_end}")
+
+    t = 0.0; step = 0; hist = []
+    while t < t_end:
+        step += 1
+        dt = compute_timestep(a, b, dx, dy, CFL, dt_min_cap, mu_s, rho_s, 0.0,
+                              rho_f, mu_f=mu_f, kappa=kappa)
+        if t + dt > t_end:
+            dt = t_end - t
+
+        # rebuild each level set, advect each reference map, re-extrapolate
+        phi_a = rebuild_phi_from_reference_map(X1a, X2a, phi_init_a)
+        phi_b = rebuild_phi_from_reference_map(X1b, X2b, phi_init_b)
+        ma = (phi_a <= 0).astype(float); mb = (phi_b <= 0).astype(float)
+        X1a = advect_reference_map(X1a, a, b, X, Y, dt, dx, dy, phi_a, 'semilagrangian', 0.0) * ma
+        X2a = advect_reference_map(X2a, a, b, X, Y, dt, dx, dy, phi_a, 'semilagrangian', 0.0) * ma
+        X1b = advect_reference_map(X1b, a, b, X, Y, dt, dx, dy, phi_b, 'semilagrangian', 0.0) * mb
+        X2b = advect_reference_map(X2b, a, b, X, Y, dt, dx, dy, phi_b, 'semilagrangian', 0.0) * mb
+        X1a, X2a = extrapolate_reference_map(X1a, X2a, phi_a, dx, dy, nl)
+        X1b, X2b = extrapolate_reference_map(X1b, X2b, phi_b, dx, dy, nl)
+        phi_a = rebuild_phi_from_reference_map(X1a, X2a, phi_init_a)
+        phi_b = rebuild_phi_from_reference_map(X1b, X2b, phi_init_b)
+
+        a_star, b_star, Jmin = momentum_step_rk4_2solids(
+            a, b, p, X1a, X2a, X1b, X2b, free_slip_box_bc, mu_s, kappa, eta_s,
+            dx, dy, dt, rho_s, rho_f, phi_a, phi_b, mu_f, w_t, k_rep=k_rep, w_c=w_c)
+
+        Ha = smoothed_heaviside(phi_a, w_t); Hb = smoothed_heaviside(phi_b, w_t)
+        rho_local = (Ha + Hb - 1) * rho_f + (1 - Ha) * rho_s + (1 - Hb) * rho_s
+        a, b, p, A, ml = pressure_projection_amg(
+            a_star, b_star, dx, dy, dt, rho_local, velocity_bc=free_slip_box_bc,
+            A=A, ml=ml, p_prev=p, eigenvalues=eig, bc_type='neumann')
+
+        cxa, cya = disc_centroid(phi_a, X, Y)
+        cxb, cyb = disc_centroid(phi_b, X, Y)
+        gap = cxb - cxa
+        t += dt
+        hist.append((t, cxa, cxb, gap, Jmin.min()))
+        if step % 50 == 0 or t >= t_end:
+            print(f"  step {step:5d} t={t:5.3f}  cxa={cxa:.3f} cxb={cxb:.3f} "
+                  f"gap={gap:.3f}  minJ={Jmin.min():.3f}  max|u|={np.max(np.hypot(a,b)):.3f}")
+
+    hist = np.array(hist)
+    np.savetxt(os.path.join(out_dir, "centroids.csv"), hist, delimiter=",",
+               header="t,cxa,cxb,gap,minJ", comments="")
+    gmin = hist[:, 3].min()
+    approached = hist[:, 3].argmin() < len(hist) - 1
+    rebounded = hist[-1, 3] > gmin + 1e-3
+    print(f"[contact] min center gap = {gmin:.3f} (2R={2*R:.3f}); "
+          f"{'REBOUND' if (approached and rebounded) else 'no clear rebound'}; "
+          f"no pass-through: {gmin > 0}")
+    try:
+        import matplotlib; matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        plt.figure(figsize=(6, 4))
+        plt.plot(hist[:, 0], hist[:, 1], label="left disc cx")
+        plt.plot(hist[:, 0], hist[:, 2], label="right disc cx")
+        plt.plot(hist[:, 0], hist[:, 3], "k--", label="center gap")
+        plt.axhline(2 * R, color="r", ls=":", label="2R (touching)")
+        plt.xlabel("t"); plt.ylabel("x"); plt.legend(); plt.tight_layout()
+        plt.savefig(os.path.join(out_dir, "contact_centroids.png"), dpi=130)
+        print(f"  saved {out_dir}/contact_centroids.png")
+    except Exception as e:
+        print(f"  (plot skipped: {e})")
+    return hist
+
+
+if __name__ == "__main__":
+    N = int(sys.argv[1]) if len(sys.argv) > 1 else 128
+    t_end = float(sys.argv[2]) if len(sys.argv) > 2 else 2.0
+    V0 = float(sys.argv[3]) if len(sys.argv) > 3 else 0.15
+    k_rep = float(sys.argv[4]) if len(sys.argv) > 4 else 2.0
+    run(N=N, t_end=t_end, V0=V0, k_rep=k_rep)

--- a/pyRMT/__init__.py
+++ b/pyRMT/__init__.py
@@ -10,6 +10,7 @@ from pyRMT.functions import (
     solid_cauchy_stress,
     smoothed_heaviside,
     momentum_step_rk4,
+    momentum_step_rk4_2solids,
     compute_curvature,
     compute_contact_force,
     velocity_rhs_blended_optimized,

--- a/pyRMT/functions.py
+++ b/pyRMT/functions.py
@@ -675,6 +675,73 @@ def momentum_step_rk4(u, v, p, X1, X2, velocity_bc, mu_s, kappa, eta_s , dx, dy,
     return u_new, v_new, sigma_sxx_elastic, sigma_sxy_elastic, sigma_syy_elastic, J
 
 
+def momentum_step_rk4_2solids(u, v, p, X1a, X2a, X1b, X2b, velocity_bc,
+                              mu_s, kappa, eta_s, dx, dy, dt, rho_s, rho_f,
+                              phi_a, phi_b, mu_f, w_t, k_rep=0.0, w_c=None):
+    """RK4 momentum step for TWO neo-Hookean solids sharing one velocity/pressure
+    field, with a repulsive solid-solid contact force.
+
+    Two reference maps (X1a,X2a), (X1b,X2b) give two solid stresses; they are
+    combined with the fluid stress via the n=2 one-fluid mixture (Jain 2019 Eq. 29):
+
+        sigma = (Ha+Hb-1) sigma_f + (1-Ha) sigma_sA + (1-Hb) sigma_sB
+        rho   = (Ha+Hb-1) rho_f   + (1-Ha) rho_s    + (1-Hb) rho_s
+
+    A short-range repulsion `compute_contact_force(phi_a,phi_b,k_rep,w_c)` is added
+    as a body force (k_rep<=0 disables it). Returns (u_new, v_new, min(Ja,Jb)).
+    """
+    if w_c is None:
+        w_c = 2.0 * w_t
+
+    # elastic stresses (constant during the RK4 stages)
+    sAxx, sAxy, sAyy, Ja = solid_cauchy_stress(X1a, X2a, dx, dy, mu_s, kappa, phi_a)
+    sBxx, sBxy, sByy, Jb = solid_cauchy_stress(X1b, X2b, dx, dy, mu_s, kappa, phi_b)
+
+    Ha = smoothed_heaviside(phi_a, w_t)
+    Hb = smoothed_heaviside(phi_b, w_t)
+    Hf = Ha + Hb - 1.0                                  # fluid fraction
+    rho_local = Hf * rho_f + (1.0 - Ha) * rho_s + (1.0 - Hb) * rho_s
+
+    if k_rep > 0.0:
+        fcx, fcy = compute_contact_force(phi_a, phi_b, k_rep, w_c, dx, dy)
+    else:
+        fcx = fcy = 0.0
+
+    def rhs(u_stage, v_stage):
+        u_stage, v_stage = apply_velocity_BCs(velocity_bc, u_stage, v_stage)
+        du_dx = grad_central_x_2nd(u_stage, dx)
+        dv_dy = grad_central_y_2nd(v_stage, dy)
+        du_dy = grad_central_y_2nd(u_stage, dy)
+        dv_dx = grad_central_x_2nd(v_stage, dx)
+        sfxx = 2.0 * mu_f * du_dx
+        sfyy = 2.0 * mu_f * dv_dy
+        sfxy = mu_f * (du_dy + dv_dx)
+        # n=2 blended Cauchy stress
+        sig_xx = Hf * sfxx + (1.0 - Ha) * sAxx + (1.0 - Hb) * sBxx
+        sig_yy = Hf * sfyy + (1.0 - Ha) * sAyy + (1.0 - Hb) * sByy
+        sig_xy = Hf * sfxy + (1.0 - Ha) * sAxy + (1.0 - Hb) * sBxy
+        div_x = grad_central_x_2nd(sig_xx, dx) + grad_central_y_2nd(sig_xy, dy)
+        div_y = grad_central_x_2nd(sig_xy, dx) + grad_central_y_2nd(sig_yy, dy)
+        u_adv = -u_stage * diff_upwind_3rd(u_stage, u_stage, dx, 1) \
+                - v_stage * diff_upwind_3rd(u_stage, v_stage, dy, 0)
+        v_adv = -u_stage * diff_upwind_3rd(v_stage, u_stage, dx, 1) \
+                - v_stage * diff_upwind_3rd(v_stage, v_stage, dy, 0)
+        dp_dx = grad_central_x_2nd(p, dx)
+        dp_dy = grad_central_y_2nd(p, dy)
+        rhs_u = u_adv + (div_x + fcx - dp_dx) / (rho_local + 1e-12)
+        rhs_v = v_adv + (div_y + fcy - dp_dy) / (rho_local + 1e-12)
+        return rhs_u, rhs_v
+
+    k1u, k1v = rhs(u, v)
+    k2u, k2v = rhs(u + 0.5 * dt * k1u, v + 0.5 * dt * k1v)
+    k3u, k3v = rhs(u + 0.5 * dt * k2u, v + 0.5 * dt * k2v)
+    k4u, k4v = rhs(u + dt * k3u, v + dt * k3v)
+    u_new = u + (dt / 6.0) * (k1u + 2 * k2u + 2 * k3u + k4u)
+    v_new = v + (dt / 6.0) * (k1v + 2 * k2v + 2 * k3v + k4v)
+    u_new, v_new = apply_velocity_BCs(velocity_bc, u_new, v_new)
+    return u_new, v_new, np.minimum(Ja, Jb)
+
+
 @njit(cache=True)
 def compute_curvature(phi, dx, dy) -> np.ndarray:
     """

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -40,3 +40,25 @@ def test_contact_force_zero_when_far_apart():
     phi2 = _disc(X, Y, 0.75, 0.5, R)
     fx, fy = compute_contact_force(phi1, phi2, k_rep=1.0, w_c=2 * dx, dx=dx, dy=dy)
     assert np.allclose(fx, 0.0) and np.allclose(fy, 0.0)
+
+
+def test_two_solid_momentum_step_runs():
+    """The two-solid momentum step (blended stress + contact force) runs and
+    returns finite fields for two nearby discs."""
+    from pyRMT.functions import (momentum_step_rk4_2solids, apply_phi_BCs,
+                                 extrapolate_reference_map)
+    N = 48
+    X, Y, dx, dy = create_grid(N, N, 1.0, 1.0)
+    R = 0.15
+    pa = apply_phi_BCs(_disc(X, Y, 0.35, 0.5, R))
+    pb = apply_phi_BCs(_disc(X, Y, 0.65, 0.5, R))
+    ma = (pa <= 0).astype(float); mb = (pb <= 0).astype(float)
+    X1a, X2a = extrapolate_reference_map(X * ma, Y * ma, pa, dx, dy, 3)
+    X1b, X2b = extrapolate_reference_map(X * mb, Y * mb, pb, dx, dy, 3)
+    bc = lambda u, v: (u.copy(), v.copy())
+    u = np.zeros((N, N)); v = np.zeros((N, N)); p = np.zeros((N, N))
+    un, vn, Jmin = momentum_step_rk4_2solids(
+        u, v, p, X1a, X2a, X1b, X2b, bc, 1.0, 0.0, 0.0, dx, dy, 1e-3, 1.0, 1.0,
+        pa, pb, 0.01, 2 * dx, k_rep=2.0, w_c=3 * dx)
+    assert np.all(np.isfinite(un)) and np.all(np.isfinite(vn))
+    assert np.all(np.isfinite(Jmin))


### PR DESCRIPTION
Builds the multi-solid contact feature on the contact-force primitive merged in #19.

## Core
- `momentum_step_rk4_2solids`: two reference maps -> two neo-Hookean stresses, combined with the fluid stress via the n=2 one-fluid mixture (Jain 2019 Eq. 29: sigma=(Ha+Hb-1)sigma_f+(1-Ha)sigma_sA+(1-Hb)sigma_sB), plus the repulsive contact force, shared velocity/pressure, RK4.

## Driver
- `two_disc_contact.py`: two soft discs driven together. The contact force prevents inter-penetration -- the centre gap approaches but stays above 2R (no pass-through), the discs compress elastically (min J ~ 0.74), and the run is stable.

## Honest status
The multi-solid machinery works and contact prevents overlap. The approach is cushioned by the incompressible fluid between the discs (physical lubrication) and the contact band (w_c) engages before hard contact, so this gentle setup settles rather than showing a sharp rebound. Reproducing the energetic collision/rebound of Jain Sec. 4.6 (stiff solids, high density ratio) is a tuning + validation follow-up.

27 unit tests pass (incl. contact-force direction/locality + the two-solid step).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)